### PR TITLE
Reset the time slider's time extent when it is reopened

### DIFF
--- a/src/main/js/bundles/dn_timeslider/TimeSliderWidgetController.ts
+++ b/src/main/js/bundles/dn_timeslider/TimeSliderWidgetController.ts
@@ -52,6 +52,9 @@ export default class TimeSliderWidgetController {
 
     public onToolActivated(): void {
         this.getView().then((view: __esri.View) => {
+            // Whenever the TimeSlider is opened, we want to (re)set it to the configured time extent.
+            this.timeSliderWidget.timeExtent = this.getTimeExtentFromConfig(this._properties, "timeExtent");
+
             view.timeExtent = this.timeSliderWidget.timeExtent;
             this.changeAllLayerTimeExtents(view.timeExtent);
             if (this._properties.playOnStartup) {

--- a/src/main/js/bundles/dn_timeslider/TimeSliderWidgetController.ts
+++ b/src/main/js/bundles/dn_timeslider/TimeSliderWidgetController.ts
@@ -61,6 +61,7 @@ export default class TimeSliderWidgetController {
                 this.timeSliderWidget.play();
             }
             this.timeExtentWatcher = this.timeSliderWidget.watch("timeExtent", (value: __esri.TimeExtent) => {
+                view.timeExtent = value;
                 this.changeAllLayerTimeExtents(value);
             });
         });

--- a/src/main/js/bundles/dn_timeslider/TimeSliderWidgetFactory.ts
+++ b/src/main/js/bundles/dn_timeslider/TimeSliderWidgetFactory.ts
@@ -16,20 +16,12 @@
 
 import { InjectedReference } from "apprt-core/InjectedReference";
 import EsriDijit from "esri-widgets/EsriDijit";
-import Binding, { Bindable, Binding as BindingType } from 'apprt-binding/Binding';
 
-import { MapWidgetModel } from "map-widget/api";
 import type TimeSliderWidgetController from "./TimeSliderWidgetController";
 
 export default class TimeSliderWidgetFactory {
 
-    private binding: BindingType;
-    private _mapWidgetModel: InjectedReference<MapWidgetModel>;
-    private _timeSliderWidgetController: TimeSliderWidgetController;
-
-    public deactivate(): void {
-        this.deactivateBinding();
-    }
+    private _timeSliderWidgetController: InjectedReference<TimeSliderWidgetController>;
 
     public createInstance(): any {
         return this.getWidget();
@@ -37,18 +29,6 @@ export default class TimeSliderWidgetFactory {
 
     private getWidget(): any {
         const timeSliderWidget = this._timeSliderWidgetController.getWidget();
-        const mapWidgetModel = this._mapWidgetModel;
-
-        this.binding = Binding.for(timeSliderWidget as Bindable, mapWidgetModel)
-            .syncToLeft("view")
-            .enable()
-            .syncToLeftNow();
-
         return new (EsriDijit as any)(timeSliderWidget);
-    }
-
-    private deactivateBinding(): void {
-        this.binding.unbind();
-        this.binding = undefined;
     }
 }

--- a/src/main/js/bundles/dn_timeslider/manifest.json
+++ b/src/main/js/bundles/dn_timeslider/manifest.json
@@ -13,8 +13,7 @@
     "dependencies": {
         "esri": "^4.20.0",
         "esri-widgets": "^4.12.0",
-        "map-widget": "^4.12.0",
-        "apprt-binding": "^4.12.0"
+        "map-widget": "^4.12.0"
     },
     "CSS-Themes-Extension": [
         {

--- a/src/main/js/bundles/dn_timeslider/manifest.json
+++ b/src/main/js/bundles/dn_timeslider/manifest.json
@@ -153,10 +153,6 @@
             },
             "references": [
                 {
-                    "name": "_mapWidgetModel",
-                    "providing": "map-widget.MapWidgetModel"
-                },
-                {
                     "name": "_timeSliderWidgetController",
                     "providing": "dn_timeslider.TimeSliderWidgetController"
                 }


### PR DESCRIPTION
Previously, when the time slider was opened for the first time, its time extent was set to the configuration property `timeExtent`. Whenever the time slider was opened subsequently, the time extent was instead set to the time extent that was initially held by the view (or configured through the `viewTimeExtent` property).

This PR makes it so that opening the time slider always sets the configured `timeExtent`, whether it is opened for the first time or second time.

Additionally, this separates the esri TimeSlider from the esri MapView because we manually update the view's and all layers' time extents. In this case, esri recommends not to set the `TimeSlider.view` property (see [Watch TimeSlider's timeExtent](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-TimeSlider.html)) because it can and does lead to weird behavior.